### PR TITLE
Add support for v4 `tex.sc` files and improve performance

### DIFF
--- a/src/extractors/csv.rs
+++ b/src/extractors/csv.rs
@@ -16,14 +16,16 @@ use std::{fs, path::Path};
 /// [`Error::DecompressionError`]: ./error/enum.Error.html#variant.DecompressionError
 /// [`Error::IoError`]: ./error/enum.Error.html#variant.IoError
 pub fn process_csv(data: &[u8], file_name: &str, out_dir: &Path) -> Result<(), Error> {
-    let decompressed = match utils::decompress(data) {
+    let mut output = Vec::new();
+
+    match utils::decompress(data, &mut output) {
         Ok(c) => c,
         Err(e) => return Err(e),
     };
 
     println!("\nExtracting {} file...", file_name.green().bold());
 
-    fs::write(out_dir.join(file_name), decompressed.get_ref())?;
+    fs::write(out_dir.join(file_name), output)?;
 
     Ok(())
 }

--- a/src/extractors/sc.rs
+++ b/src/extractors/sc.rs
@@ -151,7 +151,7 @@ pub fn process_sc(
         println!("\nProcessing `{}` image(s)...", file_name.green().bold());
     }
 
-    let mut stream = Reader::new(Cursor::new(data.to_vec()));
+    let mut stream = Reader::new(Cursor::new(data));
     let mut offset_shape = 0;
     let mut offset_sheet = 0;
 

--- a/src/extractors/tex.rs
+++ b/src/extractors/tex.rs
@@ -143,12 +143,13 @@ pub fn process_tex(
         .unwrap_or_default();
     let hash_length = (&raw_data[6..10]).read_u32::<BigEndian>().unwrap_or(16) as usize;
 
-    let decompressed = match version {
-        0 | 1 | 3 => utils::decompress(&raw_data[10 + hash_length..])?,
-        _ => Cursor::new(raw_data.to_vec()),
+    let mut output = Vec::new();
+    match version {
+        0 | 1 | 3 => utils::decompress(&raw_data[10 + hash_length..], &mut output)?,
+        _ => output = raw_data.to_vec(),
     };
 
-    let mut reader = Reader::new(decompressed);
+    let mut reader = Reader::new(Cursor::new(&output));
 
     let mut pic_count = 0;
     let possible_types = [1, 24, 27, 28];

--- a/src/extractors/tex.rs
+++ b/src/extractors/tex.rs
@@ -141,11 +141,16 @@ pub fn process_tex(
     let version = (&raw_data[2..6])
         .read_u32::<BigEndian>()
         .unwrap_or_default();
-    let hash_length = (&raw_data[6..10]).read_u32::<BigEndian>().unwrap_or(16) as usize;
+
+    let (start, end) = if version == 4 { (10, 14) } else { (6, 10) };
+
+    let hash_length = (&raw_data[start..end])
+        .read_u32::<BigEndian>()
+        .unwrap_or(16) as usize;
 
     let mut output = Vec::new();
     match version {
-        0 | 1 | 3 => utils::decompress(&raw_data[10 + hash_length..], &mut output)?,
+        0 | 1 | 3 | 4 => utils::decompress(&raw_data[end + hash_length..], &mut output)?,
         _ => output = raw_data.to_vec(),
     };
 


### PR DESCRIPTION
This pull request adds support for what I assume is the version 4 of `tex.sc` files, found in Supercell's newest game, Clash Mini.

It also adds some performance improvements by reducing the number of clones.

This has been tested by extracting version 1 and version 4 `tex.sc` files.